### PR TITLE
Handle filename contains multiple "."

### DIFF
--- a/mask_the_face.py
+++ b/mask_the_face.py
@@ -169,7 +169,7 @@ if is_directory:
             write_path = dir_write_path
             if is_image(image_path):
                 # Proceed if file is image
-                split_path = f.rsplit(".")
+                split_path = [".".join(split_path[:-1]),split_path[-1]]
                 masked_image, mask, mask_binary, original_image = mask_image(
                     image_path, args
                 )

--- a/mask_the_face.py
+++ b/mask_the_face.py
@@ -133,7 +133,7 @@ if is_directory:
                 tqdm.write(str_p)
 
             split_path = f.rsplit(".")
-            split_path = ["".join(split_path[:-1]),split_path[-1]]
+            split_path = [".".join(split_path[:-1]),split_path[-1]]
             masked_image, mask, mask_binary_array, original_image = mask_image(
                 image_path, args
             )

--- a/mask_the_face.py
+++ b/mask_the_face.py
@@ -133,6 +133,7 @@ if is_directory:
                 tqdm.write(str_p)
 
             split_path = f.rsplit(".")
+            split_path = ["".join(split_path[:-1]),split_path[-1]]
             masked_image, mask, mask_binary_array, original_image = mask_image(
                 image_path, args
             )


### PR DESCRIPTION
split_path = f.rsplit(".") only can't handle filenames that contain more than "." Ex: file.30.26.jpg
It will produce an opencv write error. (It will try to cv.imwrite("file.30",img ).
In this modification, I join all elements of split_path array from the start to (n - 1) th to create new split_path with just 2 elements.
Ex: file.30.26.jpg -> ["file","30","26","jpg"] -> ["file.30.26","jpg"]